### PR TITLE
Comprobaciones de traducción ordenadas y sugerencias de tipo

### DIFF
--- a/src/Concerns/InteractsWithDTOTranslation.php
+++ b/src/Concerns/InteractsWithDTOTranslation.php
@@ -8,14 +8,18 @@ trait InteractsWithDTOTranslation
 {
     private function isTranslationsArray($value): bool
     {
+        if (!is_array($value)) {
+            return false;
+        }
+
         $keys = ['es', 'en'];
 
         return count($value) === 2 && Arr::has($value, $keys);
     }
 
-    private function translate(array | string | null $value): string | array | null
+    private function translate(array|string|null $value): string|array|null
     {
-        if (! is_array($value)) {
+        if (!is_array($value)) {
             return $value;
         }
 

--- a/src/Concerns/InteractsWithDTOTranslation.php
+++ b/src/Concerns/InteractsWithDTOTranslation.php
@@ -8,7 +8,7 @@ trait InteractsWithDTOTranslation
 {
     private function isTranslationsArray($value): bool
     {
-        if (!is_array($value)) {
+        if (! is_array($value)) {
             return false;
         }
 
@@ -17,9 +17,9 @@ trait InteractsWithDTOTranslation
         return count($value) === 2 && Arr::has($value, $keys);
     }
 
-    private function translate(array|string|null $value): string|array|null
+    private function translate(array | string | null $value): string | array | null
     {
-        if (!is_array($value)) {
+        if (! is_array($value)) {
             return $value;
         }
 


### PR DESCRIPTION
Agregue una protección is_array temprana en isTranslationsArray para devolver falso para valores que no sean arrays y evitar comprobaciones de clave incorrectas. Normalice el tipo de unión y el espaciado en la firma de traducción y las comprobaciones is_array para un estilo de codificación consistente. Estos cambios mejoran la seguridad al pasar valores que no son arrays y alinean el formato con las convenciones del proyecto.